### PR TITLE
Allow users to provide custom materials to OpticsBuilder instances

### DIFF
--- a/src/zemax2raysect/builders/abstract.py
+++ b/src/zemax2raysect/builders/abstract.py
@@ -2,6 +2,7 @@
 from typing import Dict
 
 from raysect.primitive import EncapsulatedPrimitive
+from raysect.optical import Material
 
 from ..surface import Surface
 from .base import LensBuilder, MirrorBuilder, OpticsBuilder
@@ -54,9 +55,10 @@ class AbstractMirrorBuilder:
         name: str,
         surface: Surface,
         direction: Direction,
+        material: Material = None,
     ) -> EncapsulatedPrimitive:
 
-        return cls.get_builder(name)().build(surface, direction)
+        return cls.get_builder(name)().build(surface, direction, material)
 
 
 class AbstractLensBuilder:
@@ -85,14 +87,15 @@ class AbstractLensBuilder:
         name: str,
         back_surface: Surface,
         front_surface: Surface,
+        material: Material = None,
     ) -> EncapsulatedPrimitive:
 
-        return cls.get_builder(name)().build(back_surface, front_surface)
+        return cls.get_builder(name)().build(back_surface, front_surface, material)
 
 
-def create_mirror(name: str, surface: Surface, direction: Direction) -> EncapsulatedPrimitive:
-    return AbstractMirrorBuilder.build(name, surface, direction)
+def create_mirror(name: str, surface: Surface, direction: Direction, material: Material = None) -> EncapsulatedPrimitive:
+    return AbstractMirrorBuilder.build(name, surface, direction, material)
 
 
-def create_lens(name: str, back_surface: Surface, front_surface: Surface) -> EncapsulatedPrimitive:
-    return AbstractLensBuilder.build(name, back_surface, front_surface)
+def create_lens(name: str, back_surface: Surface, front_surface: Surface, material: Material = None) -> EncapsulatedPrimitive:
+    return AbstractLensBuilder.build(name, back_surface, front_surface, material)

--- a/src/zemax2raysect/builders/base.py
+++ b/src/zemax2raysect/builders/base.py
@@ -1,5 +1,6 @@
 """Base classes for optical builders."""
 from raysect.primitive import EncapsulatedPrimitive
+from raysect.optical import Material
 
 from ..surface import Surface
 from .common import CannotCreatePrimitive, Direction
@@ -26,12 +27,14 @@ class OpticsBuilder:
         """
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
-    def _extract_parameters(self: "OpticsBuilder", *args: Surface) -> None:
+    def _extract_parameters(self: "OpticsBuilder", *args: Surface, material: Material = None) -> None:
         """Extract parameters required to build an optical element.
 
         Parameters
         ----------
         args : Surface
+        material : Material
+            Default is None. User-defined Raysect optical material for a mirror or a lens.
 
         Returns
         -------
@@ -39,7 +42,7 @@ class OpticsBuilder:
         """
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
-    def build(self: "OpticsBuilder", *args: Surface) -> EncapsulatedPrimitive:
+    def build(self: "OpticsBuilder", *args: Surface, material: Material = None) -> EncapsulatedPrimitive:
         """Build an optical element.
 
         Parameters
@@ -47,6 +50,8 @@ class OpticsBuilder:
         args : Surface
             A sequence of surfaces which define an optical element.
             For example, one -- for a mirror, two -- for a lens.
+        material : Material
+            Default is None. User-defined Raysect optical material for a mirror or a lens.
 
         Returns
         -------
@@ -86,11 +91,11 @@ class MirrorBuilder(OpticsBuilder):
         Build a mirror using a surface parameters.
     """
 
-    def _extract_parameters(self: "LensBuilder", surface: Surface) -> None:
+    def _extract_parameters(self: "LensBuilder", surface: Surface, material: Material = None) -> None:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
     def build(
-        self: "MirrorBuilder", surface: Surface, direction: Direction
+        self: "MirrorBuilder", surface: Surface, direction: Direction, material: Material = None
     ) -> EncapsulatedPrimitive:
         """Build a mirror using a surface parameters.
 
@@ -99,6 +104,8 @@ class MirrorBuilder(OpticsBuilder):
         surface : Surface
         direction : {-1, 1}
             Ray propagation direction.
+        material : Material
+            Default is None. User-defined Raysect optical material of the mirror.
 
         Returns
         -------
@@ -109,12 +116,12 @@ class MirrorBuilder(OpticsBuilder):
 
 class LensBuilder(OpticsBuilder):
     def _extract_parameters(
-        self: "LensBuilder", back_surface: Surface, front_surface: Surface
+        self: "LensBuilder", back_surface: Surface, front_surface: Surface, material: Material = None
     ) -> None:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
     def build(
-        self: "LensBuilder", back_surface: Surface, front_surface: Surface
+        self: "LensBuilder", back_surface: Surface, front_surface: Surface, material: Material = None
     ) -> EncapsulatedPrimitive:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 

--- a/src/zemax2raysect/builders/surface.py
+++ b/src/zemax2raysect/builders/surface.py
@@ -46,12 +46,15 @@ class CircleBuilder(MirrorBuilder):
     def _extract_parameters(
         self: "CircleBuilder",
         surface: Union[Standard, Toroidal],
+        material: Material = None,
     ) -> None:
         """Extract parameters from a surface description.
 
         Parameters
         ----------
         surface : Standard or Toroidal
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -70,14 +73,18 @@ class CircleBuilder(MirrorBuilder):
         if shape_type is not ShapeType.ROUND:
             raise CannotCreatePrimitive(f"Cannot create Circle from {surface}: it is not round")
 
+        if material and not isinstance(material, Material):
+            raise TypeError(f"Cannot create a mirror from {surface}: material must be a Raysect Material.")
+
         self._radius = surface.semi_diameter
-        self._material = find_material(surface.material)
+        self._material = material or find_material(surface.material)
         self._name = surface.name
 
     def build(
         self: "CircleBuilder",
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Circle:
         """Create a raysect.primitive.Cylinder using parameters from a surface description.
 
@@ -85,13 +92,15 @@ class CircleBuilder(MirrorBuilder):
         ----------
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
         Circle
         """
         self._clear_parameters()
-        self._extract_parameters(surface)
+        self._extract_parameters(surface, material)
 
         return Circle(self._radius, material=self._material, name=self._name)
 
@@ -123,12 +132,15 @@ class RectangleBuilder(MirrorBuilder):
     def _extract_parameters(
         self: "RectangleBuilder",
         surface: Union[Standard, Toroidal],
+        material: Material = None,
     ) -> None:
         """Extract parameters from a surface description.
 
         Parameters
         ----------
         surface : Standard or Toroidal
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -162,13 +174,14 @@ class RectangleBuilder(MirrorBuilder):
 
         self._width = surface.aperture[0] * 2
         self._height = surface.aperture[1] * 2
-        self._material = find_material(surface.material)
+        self._material = material or find_material(surface.material)
         self._name = surface.name
 
     def build(
         self: "RectangleBuilder",
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Rectangle:
         """Create an instance Rectangle using parameters from a surface description.
 
@@ -176,6 +189,8 @@ class RectangleBuilder(MirrorBuilder):
         ----------
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -222,6 +237,7 @@ class AbstractSurfacePrimitiveBuilder:
         name: str,
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Union[Circle, Rectangle]:
         """Build a primitive with a requested name.
 
@@ -230,17 +246,19 @@ class AbstractSurfacePrimitiveBuilder:
         name : str
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
         Circle or Rectangle
         """
-        return cls.get_builder(name)().build(surface, direction)
+        return cls.get_builder(name)().build(surface, direction, material)
 
 
-def create_circle(surface: Union[Standard, Toroidal], direction: Direction = 1) -> Circle:
-    return CircleBuilder().build(surface, direction)
+def create_circle(surface: Union[Standard, Toroidal], direction: Direction = 1, material: Material = None) -> Circle:
+    return CircleBuilder().build(surface, direction, material)
 
 
-def create_rectangle(surface: Union[Standard, Toroidal], direction: Direction = 1) -> Rectangle:
-    return RectangleBuilder().build(surface, direction)
+def create_rectangle(surface: Union[Standard, Toroidal], direction: Direction = 1, material: Material = None) -> Rectangle:
+    return RectangleBuilder().build(surface, direction, material)


### PR DESCRIPTION
This PR fixes #4 by adding `materials` keyword argument to `OpticalNodeBuilder.build()` and `create_optical_node()` and `material` keyword argument to `OpticsBuilder.build()`. The `materials` argument is a dictionary of Raysect materials, where the keys can be either surface names or Zemax material names.

This PR also removes duplicated calls of
```python
self._clear_parameters()
self._extract_parameters(...)
```
in the protected `_build_{something}()` methods of `OpticsBuilder` instances since these methods are called in the public `build()` method.

This also removes duplicated
```
padding = current_surface.thickness * 1.0e-6
self._current_transform *= translate(0, 0, current_surface.thickness + padding)
```
in the `OpticalNodeBuilder.build()`.

These PR is made on top of #2. 

I'm preparing a demo that will show this new feature.