### PR TITLE
Redo cylindrical and spherical mirrors as CSG primitives and add suport for round and rectangular apertures

### DIFF
--- a/src/zemax2raysect/builders/abstract.py
+++ b/src/zemax2raysect/builders/abstract.py
@@ -2,6 +2,7 @@
 from typing import Dict
 
 from raysect.primitive import EncapsulatedPrimitive
+from raysect.optical import Material
 
 from ..surface import Surface
 from .base import LensBuilder, MirrorBuilder, OpticsBuilder
@@ -54,9 +55,10 @@ class AbstractMirrorBuilder:
         name: str,
         surface: Surface,
         direction: Direction,
+        material: Material = None,
     ) -> EncapsulatedPrimitive:
 
-        return cls.get_builder(name)().build(surface, direction)
+        return cls.get_builder(name)().build(surface, direction, material)
 
 
 class AbstractLensBuilder:
@@ -85,14 +87,15 @@ class AbstractLensBuilder:
         name: str,
         back_surface: Surface,
         front_surface: Surface,
+        material: Material = None,
     ) -> EncapsulatedPrimitive:
 
-        return cls.get_builder(name)().build(back_surface, front_surface)
+        return cls.get_builder(name)().build(back_surface, front_surface, material)
 
 
-def create_mirror(name: str, surface: Surface, direction: Direction) -> EncapsulatedPrimitive:
-    return AbstractMirrorBuilder.build(name, surface, direction)
+def create_mirror(name: str, surface: Surface, direction: Direction, material: Material = None) -> EncapsulatedPrimitive:
+    return AbstractMirrorBuilder.build(name, surface, direction, material)
 
 
-def create_lens(name: str, back_surface: Surface, front_surface: Surface) -> EncapsulatedPrimitive:
-    return AbstractLensBuilder.build(name, back_surface, front_surface)
+def create_lens(name: str, back_surface: Surface, front_surface: Surface, material: Material = None) -> EncapsulatedPrimitive:
+    return AbstractLensBuilder.build(name, back_surface, front_surface, material)

--- a/src/zemax2raysect/builders/base.py
+++ b/src/zemax2raysect/builders/base.py
@@ -1,5 +1,6 @@
 """Base classes for optical builders."""
 from raysect.primitive import EncapsulatedPrimitive
+from raysect.optical import Material
 
 from ..surface import Surface
 from .common import CannotCreatePrimitive, Direction
@@ -26,12 +27,14 @@ class OpticsBuilder:
         """
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
-    def _extract_parameters(self: "OpticsBuilder", *args: Surface) -> None:
+    def _extract_parameters(self: "OpticsBuilder", *args: Surface, material: Material = None) -> None:
         """Extract parameters required to build an optical element.
 
         Parameters
         ----------
         args : Surface
+        material : Material
+            Default is None. User-defined Raysect optical material for a mirror or a lens.
 
         Returns
         -------
@@ -39,7 +42,7 @@ class OpticsBuilder:
         """
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
-    def build(self: "OpticsBuilder", *args: Surface) -> EncapsulatedPrimitive:
+    def build(self: "OpticsBuilder", *args: Surface, material: Material = None) -> EncapsulatedPrimitive:
         """Build an optical element.
 
         Parameters
@@ -47,6 +50,8 @@ class OpticsBuilder:
         args : Surface
             A sequence of surfaces which define an optical element.
             For example, one -- for a mirror, two -- for a lens.
+        material : Material
+            Default is None. User-defined Raysect optical material for a mirror or a lens.
 
         Returns
         -------
@@ -86,11 +91,11 @@ class MirrorBuilder(OpticsBuilder):
         Build a mirror using a surface parameters.
     """
 
-    def _extract_parameters(self: "LensBuilder", surface: Surface) -> None:
+    def _extract_parameters(self: "LensBuilder", surface: Surface, material: Material = None) -> None:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
     def build(
-        self: "MirrorBuilder", surface: Surface, direction: Direction
+        self: "MirrorBuilder", surface: Surface, direction: Direction, material: Material = None
     ) -> EncapsulatedPrimitive:
         """Build a mirror using a surface parameters.
 
@@ -99,6 +104,8 @@ class MirrorBuilder(OpticsBuilder):
         surface : Surface
         direction : {-1, 1}
             Ray propagation direction.
+        material : Material
+            Default is None. User-defined Raysect optical material of the mirror.
 
         Returns
         -------
@@ -109,12 +116,12 @@ class MirrorBuilder(OpticsBuilder):
 
 class LensBuilder(OpticsBuilder):
     def _extract_parameters(
-        self: "LensBuilder", back_surface: Surface, front_surface: Surface
+        self: "LensBuilder", back_surface: Surface, front_surface: Surface, material: Material = None
     ) -> None:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
     def build(
-        self: "LensBuilder", back_surface: Surface, front_surface: Surface
+        self: "LensBuilder", back_surface: Surface, front_surface: Surface, material: Material = None
     ) -> EncapsulatedPrimitive:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 

--- a/src/zemax2raysect/builders/common.py
+++ b/src/zemax2raysect/builders/common.py
@@ -64,7 +64,7 @@ def determine_primitive_type(surface: Union[Standard, Toroidal]) -> Tuple[Surfac
 
     # shape_type = ShapeType.RECTANGULAR if surface.aperture is not None else ShapeType.ROUND
 
-    if surface.aperture is not None and surface.aperture_decenter is None:
+    if surface.aperture is not None and surface.aperture_type == 'rectangular':
         shape_type = ShapeType.RECTANGULAR
     else:
         shape_type = ShapeType.ROUND

--- a/src/zemax2raysect/builders/cylindrical.py
+++ b/src/zemax2raysect/builders/cylindrical.py
@@ -37,7 +37,6 @@ class CylindricalMirrorBuilder(MirrorBuilder):
 
     def _clear_parameters(self: "CylindricalMirrorBuilder") -> None:
         self._diameter: float = None
-        self._center_thickness: float = None
         self._curvature: float = None
         self._material: Material = None
         self._name: str = None
@@ -87,7 +86,6 @@ class CylindricalMirrorBuilder(MirrorBuilder):
             self._rotation = rotate_z(90)
 
         self._diameter = 2 * surface.semi_diameter
-        self._center_thickness = surface.thickness or DEFAULT_THICKNESS
         self._material = find_material(surface.material)
         self._name = surface.name
 
@@ -113,7 +111,6 @@ class CylindricalMirrorBuilder(MirrorBuilder):
 
         mirror = CylindricalMirror(
             self._diameter,
-            self._center_thickness,
             self._curvature,
             material=self._material,
             name=self._name,

--- a/src/zemax2raysect/builders/surface.py
+++ b/src/zemax2raysect/builders/surface.py
@@ -46,12 +46,15 @@ class CircleBuilder(MirrorBuilder):
     def _extract_parameters(
         self: "CircleBuilder",
         surface: Union[Standard, Toroidal],
+        material: Material = None,
     ) -> None:
         """Extract parameters from a surface description.
 
         Parameters
         ----------
         surface : Standard or Toroidal
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -70,14 +73,18 @@ class CircleBuilder(MirrorBuilder):
         if shape_type is not ShapeType.ROUND:
             raise CannotCreatePrimitive(f"Cannot create Circle from {surface}: it is not round")
 
+        if material and not isinstance(material, Material):
+            raise TypeError(f"Cannot create a mirror from {surface}: material must be a Raysect Material.")
+
         self._radius = surface.semi_diameter
-        self._material = find_material(surface.material)
+        self._material = material or find_material(surface.material)
         self._name = surface.name
 
     def build(
         self: "CircleBuilder",
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Circle:
         """Create a raysect.primitive.Cylinder using parameters from a surface description.
 
@@ -85,13 +92,15 @@ class CircleBuilder(MirrorBuilder):
         ----------
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
         Circle
         """
         self._clear_parameters()
-        self._extract_parameters(surface)
+        self._extract_parameters(surface, material)
 
         return Circle(self._radius, material=self._material, name=self._name)
 
@@ -123,12 +132,15 @@ class RectangleBuilder(MirrorBuilder):
     def _extract_parameters(
         self: "RectangleBuilder",
         surface: Union[Standard, Toroidal],
+        material: Material = None,
     ) -> None:
         """Extract parameters from a surface description.
 
         Parameters
         ----------
         surface : Standard or Toroidal
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -162,13 +174,14 @@ class RectangleBuilder(MirrorBuilder):
 
         self._width = surface.aperture[0] * 2
         self._height = surface.aperture[1] * 2
-        self._material = find_material(surface.material)
+        self._material = material or find_material(surface.material)
         self._name = surface.name
 
     def build(
         self: "RectangleBuilder",
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Rectangle:
         """Create an instance Rectangle using parameters from a surface description.
 
@@ -176,6 +189,8 @@ class RectangleBuilder(MirrorBuilder):
         ----------
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
@@ -222,6 +237,7 @@ class AbstractSurfacePrimitiveBuilder:
         name: str,
         surface: Union[Standard, Toroidal],
         direction: Direction = 1,
+        material: Material = None,
     ) -> Union[Circle, Rectangle]:
         """Build a primitive with a requested name.
 
@@ -230,17 +246,19 @@ class AbstractSurfacePrimitiveBuilder:
         name : str
         surface : Standard or Toroidal
         direction : {-1, 1}, default = 1
+        material : Material
+            Custom mirror material. Default is None (ideal mirror).
 
         Returns
         -------
         Circle or Rectangle
         """
-        return cls.get_builder(name)().build(surface, direction)
+        return cls.get_builder(name)().build(surface, direction, material)
 
 
-def create_circle(surface: Union[Standard, Toroidal], direction: Direction = 1) -> Circle:
-    return CircleBuilder().build(surface, direction)
+def create_circle(surface: Union[Standard, Toroidal], direction: Direction = 1, material: Material = None) -> Circle:
+    return CircleBuilder().build(surface, direction, material)
 
 
-def create_rectangle(surface: Union[Standard, Toroidal], direction: Direction = 1) -> Rectangle:
-    return RectangleBuilder().build(surface, direction)
+def create_rectangle(surface: Union[Standard, Toroidal], direction: Direction = 1, material: Material = None) -> Rectangle:
+    return RectangleBuilder().build(surface, direction, material)

--- a/src/zemax2raysect/primitive/mirror/__init__.pxd
+++ b/src/zemax2raysect/primitive/mirror/__init__.pxd
@@ -1,4 +1,4 @@
 """Mirror primitives."""
-from .cylindrical cimport CylindricalMirror
-from .spherical cimport SphericalMirror
+from .cylindrical cimport RoundCylindricalMirror, RectangularCylindricalMirror
+from .spherical cimport RoundSphericalMirror, RectangularSphericalMirror
 from .toric cimport ToricMirror

--- a/src/zemax2raysect/primitive/mirror/__init__.py
+++ b/src/zemax2raysect/primitive/mirror/__init__.py
@@ -1,4 +1,4 @@
 """Mirror primitives."""
-from .cylindrical import CylindricalMirror
-from .spherical import SphericalMirror
+from .cylindrical import RoundCylindricalMirror, RectangularCylindricalMirror
+from .spherical import RoundSphericalMirror, RectangularSphericalMirror
 from .toric import ToricMirror

--- a/src/zemax2raysect/primitive/mirror/cylindrical.pyx
+++ b/src/zemax2raysect/primitive/mirror/cylindrical.pyx
@@ -1,46 +1,216 @@
-from libc.math cimport sqrt
+from libc.math cimport sqrt, abs, fmax
 
-from raysect.core cimport AffineMatrix3D, Material, translate
-from raysect.primitive import Intersect, Subtract, Sphere, Cylinder
+from raysect.core cimport AffineMatrix3D, Material, translate, rotate_y, Point3D
+from raysect.primitive import Intersect, Subtract, Cylinder, Box
 from raysect.primitive.utility cimport EncapsulatedPrimitive
 
-from ..surface.cylinder_segment cimport CylinderSegment
+
+DEF PADDING = 0.000001
 
 
-cdef class CylindricalMirror(EncapsulatedPrimitive):
+cdef class RoundCylindricalMirror(EncapsulatedPrimitive):
+    """
+    Prmitive for a round cylindrical mirror with an aperture.
+
+    A thin mirror is formed by two cylindrical surfaces, in a way that both curvature center lie in +z direction.
+    Center of the front surface lies at z=0, independent on the center of the mirror's frame in XY plane.
+    Center of the back surface lies in -z direction. The mirror is curved along y axis.
+
+    :param float diameter: Diameter of the mirror's frame in [m].
+    :param float curvature: Radius of curvature in [m].
+    :param float aperture: Diameter of the mirror aperture (cutout) in [m], concentric with the frame (default = 0).
+    :param float horizontal_decenter: Decenter of the mirror's frame and aperture along x direction in [m] (default = 0).
+    :param float vertical_decenter: Decenter of the mirror's frame and aperture along y direction in [m] (default = 0).
+    :param Node parent: Assigns the primitive's parent to the specified scene-graph object (default = None).
+    :param AffineMatrix3D transform: Sets the affine transform associated with the primitive (default = None).
+    :param Material material: An object representing the material properties of the primitive (default = None).
+    :param str name: A string defining the mirror's name (default = None).
+    """
 
     cdef:
         readonly double diameter
         readonly double curvature
         readonly double curve_thickness
+        readonly double aperture
+        readonly double horizontal_decenter
+        readonly double vertical_decenter
+        readonly double center_thickness
 
     def __init__(
-        self, 
-        double diameter, 
-        double curvature, 
-        object parent=None, 
-        AffineMatrix3D transform=None, 
-        Material material=None, 
+        self,
+        double diameter,
+        double curvature,
+        double aperture=0,
+        double horizontal_decenter=0,
+        double vertical_decenter=0,
+        object parent=None,
+        AffineMatrix3D transform=None,
+        Material material=None,
         str name=None
     ):
 
-        if diameter < 0:
-            raise ValueError(f"Cylindrical mirror's diameter cannot be less than or equal to zero, got {diameter}")
+        if diameter <= 0:
+            raise ValueError(f"Cylindrical mirror's diameter cannot be less than or equal to zero, got {diameter}.")
 
-        if curvature < 0:
-            raise ValueError(f"Cylindrical mirror's curvature cannot be less than or equal to zero, got {curvature}")
+        if curvature <= 0:
+            raise ValueError(f"Cylindrical mirror's curvature cannot be less than or equal to zero, got {curvature}.")
+
+        if aperture < 0:
+            raise ValueError(f"Cylindrical mirror's aperture cannot be less than zero, got {aperture}.")
+
+        if aperture >= diameter:
+            raise ValueError(f"Cylindrical mirror's aperture must be smaller than the diameter of its frame, got {aperture} >= {diameter}.")
 
         cdef double radius = 0.5 * diameter
+        cdef double frame_outer_x = abs(horizontal_decenter) + radius
+        cdef double cylinder_height = 2 * frame_outer_x
+        cdef double frame_outer_y = abs(vertical_decenter) + radius
+        cdef double frame_inner_y = fmax(0, abs(vertical_decenter) - radius)
 
-        if curvature < radius:
-            raise ValueError(f"Cylindrical mirror's curvature cannot be less than its frame's radius, got {curvature} >= {radius}")
+        if curvature < frame_outer_y:
+            raise ValueError("Cylindrical mirror's curvature cannot be less than the radius of its frame "
+                             f"+ |vertical_decenter|, got {curvature} < {frame_outer_y}.")
 
         self.diameter = diameter
         self.curvature = curvature
-        self.curve_thickness = curvature - sqrt(curvature * curvature - radius * radius)
+        self.aperture = aperture
+        self.horizontal_decenter = horizontal_decenter
+        self.vertical_decenter = vertical_decenter
 
-        curve = CylinderSegment(radius, self.curvature, self.curve_thickness)
-        barrel = Cylinder(radius, self.curve_thickness)
-        mirror = Intersect(curve, barrel)
+        cdef double frame_inner_z = curvature - sqrt(curvature * curvature - frame_inner_y * frame_inner_y)
+        cdef double frame_outer_z = curvature - sqrt(curvature * curvature - frame_outer_y * frame_outer_y)
+
+        self.curve_thickness = frame_outer_z - frame_inner_z
+        self.center_thickness = self.curve_thickness * PADDING
+
+        outer_cylinder = Cylinder(self.curvature + self.center_thickness, cylinder_height)
+        inner_cylinder = Cylinder(self.curvature, cylinder_height + 2 * PADDING,
+                                  transform=translate(0, 0, -PADDING))
+
+        hollow_cylinder = Subtract(outer_cylinder, inner_cylinder,
+                                   transform=translate(-frame_outer_x, 0, self.curvature) * rotate_y(90))
+
+        frame = Cylinder(radius, self.curve_thickness + self.center_thickness,
+                         transform=translate(self.horizontal_decenter,
+                                             self.vertical_decenter,
+                                             frame_inner_z - self.center_thickness))
+
+        mirror = Intersect(hollow_cylinder, frame)
+
+        if self.aperture > 0:
+            transform = translate(self.horizontal_decenter, self.vertical_decenter, frame_inner_z - self.center_thickness - PADDING)
+            aperture_cylinder = Cylinder(0.5 * self.aperture, self.curve_thickness + self.center_thickness + PADDING,
+                                         transform=transform)
+
+            mirror = Subtract(mirror, aperture_cylinder)
+
+        super().__init__(mirror, parent, transform, material, name)
+
+
+cdef class RectangularCylindricalMirror(EncapsulatedPrimitive):
+    """
+    Prmitive for a rectangular cylindrical mirror with an aperture.
+
+    A thin mirror is formed by two cylindrical surfaces, in a way that both curvature center lie in +z direction.
+    Center of the front surface lies at z=0, independent on the center of the mirror's frame in XY plane.
+    Center of the back surface lies in -z direction. The mirror is curved along y axis.
+
+    :param float width: Width of the mirror's frame along x axis in [m].
+    :param float height: Height of the mirror's frame along y axis in [m].
+    :param float curvature: Radius of curvature in meters in [m].
+    :param object aperture: Diameter of the mirror aperture (cutout) in [m], concentric with the frame (default = 0).
+    :param float horizontal_decenter: Decenter of the mirror's frame and aperture along x direction in [m] (default = 0).
+    :param float vertical_decenter: Decenter of the mirror's frame and aperture along y direction in [m] (default = 0).
+    :param Node parent: Assigns the primitive's parent to the specified scene-graph object (default = None).
+    :param AffineMatrix3D transform: Sets the affine transform associated with the primitive (default = None).
+    :param Material material: An object representing the material properties of the primitive (default = None).
+    :param str name: A string defining the mirror's name (default = None).
+    """
+
+    cdef:
+        readonly double width
+        readonly double height
+        readonly double curvature
+        readonly double curve_thickness
+        readonly double aperture
+        readonly double horizontal_decenter
+        readonly double vertical_decenter
+        readonly double center_thickness
+
+    def __init__(
+        self,
+        double width,
+        double height,
+        double curvature,
+        double aperture=0,
+        double horizontal_decenter=0,
+        double vertical_decenter=0,
+        object parent=None,
+        AffineMatrix3D transform=None,
+        Material material=None,
+        str name=None
+    ):
+
+        if width <= 0:
+            raise ValueError(f"Cylindrical mirror's width cannot be less than or equal to zero, got {width}")
+
+        if height <= 0:
+            raise ValueError(f"Cylindrical mirror's height cannot be less than or equal to zero, got {height}")
+
+        if curvature <= 0:
+            raise ValueError(f"Cylindrical mirror's curvature radius cannot be less than or equal to zero, got {curvature}")
+
+        if aperture < 0:
+            raise ValueError(f"Cylindrical mirror's aperture cannot be less than zero, got {aperture}.")
+
+        if aperture >= width:
+            raise ValueError(f"Cylindrical mirror's aperture must be smaller than the width of its frame, got {aperture} >= {width}.")
+
+        if aperture >= height:
+            raise ValueError(f"Cylindrical mirror's aperture must be smaller than the height of its frame, got {aperture} >= {height}.")
+
+        cdef double half_width = 0.5 * width
+        cdef double half_height = 0.5 * height
+        cdef double frame_outer_x = abs(horizontal_decenter) + half_width
+        cdef double cylinder_height = 2 * frame_outer_x
+        cdef double frame_outer_y = abs(vertical_decenter) + half_height
+        cdef double frame_inner_y = fmax(0, abs(vertical_decenter) - half_height)
+
+        if curvature < frame_outer_y:
+            raise ValueError("Cylindrical mirror's curvature cannot be less than the height of its frame "
+                             f"+ |vertical_decenter|, got {curvature} < {frame_outer_y}.")
+
+        self.width = width
+        self.height = height
+        self.curvature = curvature
+        self.aperture = aperture
+        self.horizontal_decenter = horizontal_decenter
+        self.vertical_decenter = vertical_decenter
+
+        cdef double frame_inner_z = curvature - sqrt(curvature * curvature - frame_inner_y * frame_inner_y)
+        cdef double frame_outer_z = curvature - sqrt(curvature * curvature - frame_outer_y * frame_outer_y)
+
+        self.curve_thickness = frame_outer_z - frame_inner_z
+        self.center_thickness = self.curve_thickness * PADDING
+
+        outer_cylinder = Cylinder(self.curvature + self.center_thickness, cylinder_height)
+        inner_cylinder = Cylinder(self.curvature, cylinder_height + 2 * PADDING,
+                                  transform=translate(0, 0, -PADDING))
+
+        hollow_cylinder = Subtract(outer_cylinder, inner_cylinder,
+                                   transform=translate(-frame_outer_x, 0, self.curvature) * rotate_y(90))
+
+        lower = Point3D(horizontal_decenter - half_width, vertical_decenter - half_height, frame_inner_z - self.center_thickness)
+        upper = Point3D(horizontal_decenter + half_width, vertical_decenter + half_height, frame_outer_z)
+        frame = Box(lower, upper)
+
+        mirror = Intersect(hollow_cylinder, frame)
+
+        if self.aperture > 0:
+            transform = translate(self.horizontal_decenter, self.vertical_decenter, frame_inner_z - self.center_thickness - PADDING)
+            aperture_cylinder = Cylinder(0.5 * self.aperture, self.curve_thickness + self.center_thickness + PADDING,
+                                         transform=transform)
+
+            mirror = Subtract(mirror, aperture_cylinder)
 
         super().__init__(mirror, parent, transform, material, name)

--- a/src/zemax2raysect/primitive/mirror/spherical.pyx
+++ b/src/zemax2raysect/primitive/mirror/spherical.pyx
@@ -1,20 +1,26 @@
-from libc.math cimport sqrt
+from libc.math cimport sqrt, fmax, fmin
 
-from raysect.core cimport AffineMatrix3D, Material, translate
-from raysect.primitive import Intersect, Subtract, Sphere, Cylinder
+from raysect.core cimport AffineMatrix3D, Material, translate, Point3D
+from raysect.primitive import Intersect, Subtract, Sphere, Cylinder, Box
 from raysect.primitive.utility cimport EncapsulatedPrimitive
 
-from ..surface.sphere_segment cimport SphereSegment
+
+DEF PADDING = 0.000001
 
 
-cdef class SphericalMirror(EncapsulatedPrimitive):
-    """Spherical mirror primitive.
+cdef class RoundSphericalMirror(EncapsulatedPrimitive):
+    """
+    Primitive for a round spherical mirror with an aperture.
 
-    A mirror is formed by two concave surfaces, in a way that both curvature center lie in +z direction.
-    Center of the front surface lies at z=0. Center of the back surface lies in -z direction.
+    A thin mirror is formed by two spherical surfaces, in a way that both curvature center lie in +z direction.
+    Center of the front surface lies at z=0, independent on the center of the mirror's frame in XY plane.
+    Center of the back surface lies in -z direction.
 
-    :param float diameter: Diameter of the mirror's frame.
-    :param float curvature: Radius of curvature in meters.
+    :param float diameter: Diameter of the mirror's frame in [m].
+    :param float curvature: Radius of curvature in meters in [m].
+    :param float aperture: Diameter of the mirror aperture (cutout) in [m], concentric with the frame (default = 0).
+    :param float horizontal_decenter: Decenter of the mirror's frame and aperture along x direction in [m] (default = 0).
+    :param float vertical_decenter: Decenter of the mirror's frame and aperture along y direction in [m] (default = 0).
     :param Node parent: Assigns the primitive's parent to the specified scene-graph object (default = None).
     :param AffineMatrix3D transform: Sets the affine transform associated with the primitive (default = None).
     :param Material material: An object representing the material properties of the primitive (default = None).
@@ -24,30 +30,191 @@ cdef class SphericalMirror(EncapsulatedPrimitive):
         readonly double diameter
         readonly double curvature
         readonly double curve_thickness
+        readonly double aperture
+        readonly double horizontal_decenter
+        readonly double vertical_decenter
+        readonly double center_thickness
 
     def __init__(
-        self, 
-        double diameter, 
-        double curvature, 
-        object parent=None, 
-        AffineMatrix3D transform=None, 
-        Material material=None, 
+        self,
+        double diameter,
+        double curvature,
+        double aperture=0,
+        double horizontal_decenter=0,
+        double vertical_decenter=0,
+        object parent=None,
+        AffineMatrix3D transform=None,
+        Material material=None,
         str name=None
     ):
-        if diameter < 0:
+        if diameter <= 0:
             raise ValueError(f"Spherical mirror's diameter cannot be less than or equal to zero, got {diameter}")
 
-        if curvature < 0:
+        if curvature <= 0:
             raise ValueError(f"Spherical mirror's curvature cannot be less than or equal to zero, got {curvature}")
 
-        cdef double radius = 0.5 * diameter
+        if aperture < 0:
+            raise ValueError(f"Spherical mirror's aperture cannot be less than zero, got {aperture}.")
 
-        if curvature < radius:
-            raise ValueError(f"Spherical mirror's curvature cannot be less than its frame's radius, got {curvature} >= {radius}")
+        if aperture >= diameter:
+            raise ValueError(f"Spherical mirror's aperture must be smaller than the diameter of its frame, got {aperture} >= {diameter}.")
+
+        cdef double radius = 0.5 * diameter
+        cdef double decenter_r = sqrt(horizontal_decenter * horizontal_decenter + vertical_decenter * vertical_decenter)
+        cdef double frame_outer_r = decenter_r + radius
+        cdef double frame_inner_r = fmax(0, decenter_r - radius)
+
+        if curvature < frame_outer_r:
+            raise ValueError("Spherical mirror's curvature cannot be less than the radius of its frame "
+                             f"+ |horizontal_decenter|, got {curvature} < {frame_outer_r}.")
 
         self.diameter = diameter
         self.curvature = curvature
+        self.aperture = aperture
+        self.horizontal_decenter = horizontal_decenter
+        self.vertical_decenter = vertical_decenter
 
-        mirror = SphereSegment(self.diameter, self.curvature)
+        cdef double frame_inner_z = curvature - sqrt(curvature * curvature - frame_inner_r * frame_inner_r)
+        cdef double frame_outer_z = curvature - sqrt(curvature * curvature - frame_outer_r * frame_outer_r)
+
+        self.curve_thickness = frame_outer_z - frame_inner_z
+        self.center_thickness = self.curve_thickness * PADDING
+
+        outer_sphere = Sphere(self.curvature + self.center_thickness)
+        inner_sphere = Sphere(self.curvature)
+
+        hollow_sphere = Subtract(outer_sphere, inner_sphere, transform=translate(0, 0, self.curvature))
+
+        frame = Cylinder(radius, self.curve_thickness + self.center_thickness,
+                         transform=translate(self.horizontal_decenter,
+                                             self.vertical_decenter,
+                                             frame_inner_z - self.center_thickness))
+
+        mirror = Intersect(hollow_sphere, frame)
+
+        if self.aperture > 0:
+            transform = translate(self.horizontal_decenter, self.vertical_decenter, frame_inner_z - self.center_thickness - PADDING)
+            aperture_cylinder = Cylinder(0.5 * self.aperture, self.curve_thickness + self.center_thickness + PADDING,
+                                         transform=transform)
+
+            mirror = Subtract(mirror, aperture_cylinder)
+
+        super().__init__(mirror, parent, transform, material, name)
+
+
+cdef class RectangularSphericalMirror(EncapsulatedPrimitive):
+    """
+    Primitive for a rectangular spherical mirror with an aperture.
+
+    A thin mirror is formed by two spherical surfaces, in a way that both curvature center lie in +z direction.
+    Center of the front surface lies at z=0, independent on the center of the mirror's frame in XY plane.
+    Center of the back surface lies in -z direction.
+
+    :param float width: width of the mirror's frame along x axis.
+    :param float height: height of the mirror's frame along y axis.
+    :param float curvature: Radius of curvature in meters.
+    :param float aperture: Diameter of the mirror aperture (cutout) in [m], concentric with the frame (default = 0).
+    :param float horizontal_decenter: Decenter of the mirror's frame and aperture along x direction in [m] (default = 0).
+    :param float vertical_decenter: Decenter of the mirror's frame and aperture along y direction in [m] (default = 0).
+    :param Node parent: Assigns the primitive's parent to the specified scene-graph object (default = None).
+    :param AffineMatrix3D transform: Sets the affine transform associated with the primitive (default = None).
+    :param Material material: An object representing the material properties of the primitive (default = None).
+    :param str name: A string defining the mirror's name (default = None).
+    """
+
+    cdef:
+        readonly double width
+        readonly double height
+        readonly double curvature
+        readonly double curve_thickness
+        readonly double aperture
+        readonly double horizontal_decenter
+        readonly double vertical_decenter
+        readonly double center_thickness
+
+    def __init__(
+        self,
+        double width,
+        double height,
+        double curvature,
+        double aperture=0,
+        double horizontal_decenter=0,
+        double vertical_decenter=0,
+        object parent=None,
+        AffineMatrix3D transform=None,
+        Material material=None,
+        str name=None
+    ):
+
+        if width <= 0:
+            raise ValueError(f"Spherical mirror's width cannot be less than or equal to zero, got {width}")
+
+        if height <= 0:
+            raise ValueError(f"Spherical mirror's height cannot be less than or equal to zero, got {height}")
+
+        if curvature <= 0:
+            raise ValueError(f"Spherical mirror's curvature radius cannot be less than or equal to zero, got {curvature}")
+
+        if aperture < 0:
+            raise ValueError(f"Spherical mirror's aperture cannot be less than zero, got {aperture}.")
+
+        if aperture >= width:
+            raise ValueError(f"Spherical mirror's aperture must be smaller than the width of its frame, got {aperture} >= {width}.")
+
+        if aperture >= height:
+            raise ValueError(f"Spherical mirror's aperture must be smaller than the height of its frame, got {aperture} >= {height}.")
+
+        cdef double half_width = 0.5 * width
+        cdef double half_height = 0.5 * height
+        cdef double frame_right = horizontal_decenter + half_width
+        cdef double frame_left = horizontal_decenter - half_width
+        cdef double frame_top = vertical_decenter + half_height
+        cdef double frame_bottom = vertical_decenter - half_height
+
+        cdef double frame_outer_x = fmax(abs(frame_right), abs(frame_left))
+        cdef double frame_outer_y = fmax(abs(frame_bottom), abs(frame_top))
+        cdef double frame_outer_r = sqrt(frame_outer_x * frame_outer_x + frame_outer_y * frame_outer_y)
+
+        if curvature < frame_outer_r:
+            raise ValueError("Spherical mirror's rectangular frame does not fit into hemisphere,"
+                             f" {curvature} < {frame_outer_r}.")
+
+        self.width = width
+        self.height = height
+        self.curvature = curvature
+        self.aperture = aperture
+        self.horizontal_decenter = horizontal_decenter
+        self.vertical_decenter = vertical_decenter
+
+        cdef double frame_inner_x = 0 if frame_left < 0 < frame_right else fmin(abs(frame_right), abs(frame_left))
+        cdef double frame_inner_y = 0 if frame_bottom < 0 < frame_top else fmin(abs(frame_bottom), abs(frame_top))
+        cdef double frame_inner_r = sqrt(frame_inner_x * frame_inner_x + frame_inner_y * frame_inner_y)
+
+        cdef double frame_inner_z = curvature - sqrt(curvature * curvature - frame_inner_r * frame_inner_r)
+        cdef double frame_outer_z = curvature - sqrt(curvature * curvature - frame_outer_r * frame_outer_r)
+
+        self.curve_thickness = frame_outer_z - frame_inner_z
+        self.center_thickness = self.curve_thickness * PADDING
+
+        outer_sphere = Sphere(self.curvature + self.center_thickness)
+        inner_sphere = Sphere(self.curvature)
+
+        hollow_sphere = Subtract(outer_sphere, inner_sphere, transform=translate(0, 0, self.curvature))
+
+        print(frame_left, frame_bottom, frame_inner_z)
+        print(frame_right, frame_top, frame_outer_z)
+
+        lower = Point3D(frame_left, frame_bottom, frame_inner_z - self.center_thickness)
+        upper = Point3D(frame_right, frame_top, frame_outer_z)
+        frame = Box(lower, upper)
+
+        mirror = Intersect(hollow_sphere, frame)
+
+        if self.aperture > 0:
+            transform = translate(self.horizontal_decenter, self.vertical_decenter, frame_inner_z - self.center_thickness - PADDING)
+            aperture_cylinder = Cylinder(0.5 * self.aperture, self.curve_thickness + self.center_thickness + PADDING,
+                                         transform=transform)
+
+            mirror = Subtract(mirror, aperture_cylinder)
 
         super().__init__(mirror, parent, transform, material, name)

--- a/src/zemax2raysect/surface.py
+++ b/src/zemax2raysect/surface.py
@@ -29,7 +29,9 @@ class SurfaceDescription:
     diam : float, default = 0
         Surface's radius. "Semi-Diameter" in LDE.
     sqap : (float, float), default = None
-        Surface's aperture width in x and y directions.
+        Surface's rectangular aperture width in x and y directions.
+    clap : (float, float), default = None
+        Surface's circular aperture min and max radii.
     obdc : (float, float), default = None
         Surface's aperture decenter in x and y directions.
     parm : dict(int, float), default = {}
@@ -49,6 +51,7 @@ class SurfaceDescription:
     glas: str = ""
     diam: float = 0.0
     sqap: Tuple[float, float] = None
+    clap: Tuple[float, float] = None
     obdc: Tuple[float, float] = None
     parm: Dict[int, float] = field(default_factory=dict)
 
@@ -110,9 +113,13 @@ class SurfaceDescription:
             if cmd == "DIAM":
                 description.diam = float(value)
 
-            # Aperture
+            # Rectangular aperture
             if cmd == "SQAP":
                 description.sqap = (float(columns[1]), float(columns[2]))
+
+            # Circular aperture
+            if cmd == "CLAP":
+                description.clap = (float(columns[1]), float(columns[2]))
 
             # Aperture decenter
             if cmd == "OBDC":
@@ -145,6 +152,8 @@ class Surface:
         Aperture width in x and y directions.
     aperture_decenter : (float, float), default = None
         Aperture decenter in x and y directions.
+    aperture_type : str, default = ""
+        Aperture type.
 
     Methods
     -------
@@ -230,7 +239,11 @@ class SurfaceBuilder:
         obj.material = description.glas
 
         if description.sqap is not None:
+            obj.aperture_type = "rectangular"
             obj.aperture = (description.sqap[0] * units_factor, description.sqap[1] * units_factor)
+        elif description.clap is not None:
+            obj.aperture_type = "circular"
+            obj.aperture = (description.clap[0] * units_factor, description.clap[1] * units_factor)
 
         if description.obdc is not None:
             obj.aperture_decenter = (


### PR DESCRIPTION
This PR fixes #6 and #7 for cylindrical and spherical mirrors. PR is done on top of #5, so #5 should be merged first. 

The PR introduces the following changes:

- `CylindricalMirror` and `SphericalMirror` classes are replaced with `RoundCylindricalMirror`, `RectangularCylindricalMirror`, `RoundSphericalMirror` and `RectangularSphericalMirror` classes, which use built-in Raysect primitives and CSG instead of custom `CylinderSegment` and `SphereSegment` primitives. The thickness (`center_thickness` attribute) of the mirrors is set to 1.E-6 of the `curve_thickness` value.
- These new classes support round apertures and de-center of both the aperture and the frame (round or rectangular).
- `CLAP` parameter (circular aperture) is added to `SurfaceDescription` class.
- New attribute `aperture_type` is added to `Surface` class. The attribute can take values `circular` or `rectangular`.
- `CylindricalMirrorBUilder` and `SphericalMirrorBuilder` are updated to support rectangular and circular apertures and aperture de-centers.
- If rectangular or circular aperture is specified, the shape of the cylindrical and spherical mirrors is determined by this aperture and not by semi-diameter (`DIAM`) parameter.