### PR TITLE
Fix incorrect lens building when ray propagation direction is negative

### DIFF
--- a/src/zemax2raysect/builders/abstract.py
+++ b/src/zemax2raysect/builders/abstract.py
@@ -87,15 +87,16 @@ class AbstractLensBuilder:
         name: str,
         back_surface: Surface,
         front_surface: Surface,
+        direction: Direction,
         material: Material = None,
     ) -> EncapsulatedPrimitive:
 
-        return cls.get_builder(name)().build(back_surface, front_surface, material)
+        return cls.get_builder(name)().build(back_surface, front_surface, direction, material)
 
 
 def create_mirror(name: str, surface: Surface, direction: Direction, material: Material = None) -> EncapsulatedPrimitive:
     return AbstractMirrorBuilder.build(name, surface, direction, material)
 
 
-def create_lens(name: str, back_surface: Surface, front_surface: Surface, material: Material = None) -> EncapsulatedPrimitive:
-    return AbstractLensBuilder.build(name, back_surface, front_surface, material)
+def create_lens(name: str, back_surface: Surface, front_surface: Surface, direction: Direction, material: Material = None) -> EncapsulatedPrimitive:
+    return AbstractLensBuilder.build(name, back_surface, front_surface, direction, material)

--- a/src/zemax2raysect/builders/base.py
+++ b/src/zemax2raysect/builders/base.py
@@ -121,7 +121,7 @@ class LensBuilder(OpticsBuilder):
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
     def build(
-        self: "LensBuilder", back_surface: Surface, front_surface: Surface, material: Material = None
+        self: "LensBuilder", back_surface: Surface, front_surface: Surface, directiion: Direction, material: Material = None
     ) -> EncapsulatedPrimitive:
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 

--- a/src/zemax2raysect/builders/node.py
+++ b/src/zemax2raysect/builders/node.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Literal, Sequence, Union
 
-from raysect.core import AffineMatrix3D, Node, translate
+from raysect.core import AffineMatrix3D, Node, translate, rotate_y
 from raysect.optical import Material
 
 from ..surface import CoordinateBreak, Surface
@@ -128,7 +128,7 @@ class OpticalNodeBuilder:
 
                 next_surface = surfaces[idx + 1]
 
-                if self._build_lens(current_surface, next_surface, node, material):
+                if self._build_lens(current_surface, next_surface, self._current_direction, node, material):
 
                     LOGGER.info(
                         "Surfaces %i and %i: a %s has been created",
@@ -252,6 +252,7 @@ class OpticalNodeBuilder:
         self: "OpticalNodeBuilder",
         current_surface: Surface,
         next_surface: Surface,
+        direction: Direction,
         parent_node: Node,
         material: Material = None,
     ) -> bool:
@@ -259,10 +260,13 @@ class OpticalNodeBuilder:
         for lens_type in AbstractLensBuilder.builders:
 
             try:
-                lens = AbstractLensBuilder.build(lens_type, current_surface, next_surface, material)
+                lens = AbstractLensBuilder.build(lens_type, current_surface, next_surface, direction, material)
 
             except CannotCreatePrimitive:
                 continue
+
+            if direction < 0:
+                lens.transform *= rotate_y(180)
 
             lens.parent = parent_node
             lens.transform = self._current_transform * lens.transform

--- a/src/zemax2raysect/builders/node.py
+++ b/src/zemax2raysect/builders/node.py
@@ -265,6 +265,7 @@ class OpticalNodeBuilder:
             except CannotCreatePrimitive:
                 continue
 
+            # rotate lens towards -Z if ray propogation direction is negative
             if direction < 0:
                 lens.transform *= rotate_y(180)
 

--- a/src/zemax2raysect/builders/toroidal.py
+++ b/src/zemax2raysect/builders/toroidal.py
@@ -109,7 +109,7 @@ class ToricMirrorBuilder(MirrorBuilder):
             )
 
         self._diameter = 2 * surface.semi_diameter
-        self._center_thickness = surface.thickness or DEFAULT_THICKNESS
+        self._center_thickness = abs(surface.thickness) or DEFAULT_THICKNESS
         self._vertical_curvature = abs(surface.radius)
         self._horizontal_curvature = abs(surface.radius_horizontal)
         self._material = material or find_material(surface.material)
@@ -178,8 +178,6 @@ class ToricLensBuilder(LensBuilder):
         self._front_curvature_horizontal: float = None
         self._material: Material = None
         self._name: str = None
-        self._back_curvature_sign: int = None
-        self._front_curvature_sign: int = None
 
     def _extract_parameters(
         self: "ToricLensBuilder",
@@ -246,6 +244,7 @@ class ToricLensBuilder(LensBuilder):
         self: "ToricLensBuilder",
         back_surface: Toroidal,
         front_surface: Toroidal,
+        direction: Direction = 1,
         material: Material = None,
     ) -> Union[ToricBiConvex, ToricBiConcave, ToricMeniscus, ToricPlanoConvex, ToricPlanoConcave]:
         """Build a toric lens using two Zemax surfaces.
@@ -256,7 +255,8 @@ class ToricLensBuilder(LensBuilder):
             Surfaces defining a lens.
         material : Material
             Custom lens material. Default is None (will search back_surface.material in the Raysect library).
-
+        direction : -1 or 1, default = 1
+            Handles a Zemax ray propagation direction.
         Returns
         -------
         EncapsulatedPrimitive
@@ -264,8 +264,8 @@ class ToricLensBuilder(LensBuilder):
         self._clear_parameters()
         self._extract_parameters(back_surface, front_surface, material)
 
-        back_sgn = sign(back_surface.radius)
-        front_sgn = sign(front_surface.radius)
+        back_sgn = sign(back_surface.radius) * sign(direction)
+        front_sgn = sign(front_surface.radius) * sign(direction)
 
         if back_sgn == 0 and front_sgn == 0:
             return create_cylinder(back_surface)


### PR DESCRIPTION
This fixes #10 by taking into account ray propagation direction when creating lenses.

- Similar to mirrors, `build` method of `LensBuilders` takes direction as an argument.
- The `_center_thickness` attribute of the `LensBuilders` takes absolute value of  `back_surface.thickness`.
- Curvature signs are determined with respect to the direction sign.
- If ray direction is negative, the lens is rotated by 180 along its Y axis when created.